### PR TITLE
add option to disable hand sway

### DIFF
--- a/src/main/java/org/polyfrost/overflowanimations/config/OldAnimationsSettings.java
+++ b/src/main/java/org/polyfrost/overflowanimations/config/OldAnimationsSettings.java
@@ -123,7 +123,8 @@ public class OldAnimationsSettings extends Config {
     @Switch(
             name = "1.7 Punching During Usage",
             description = "Purely visual feature. Re-enables the ability to consume food or block a sword whilst punching a block.",
-            subcategory = "Interaction")
+            subcategory = "Interaction"
+    )
     @VigilanceName(
             name = "Punching During Usage",
             category = "Animations",
@@ -413,6 +414,13 @@ public class OldAnimationsSettings extends Config {
             category = "Misc", subcategory = "Fixes, QOL, and Tweaks"
     )
     public static boolean noHurtCam = false;
+
+    @Switch(
+            name = "Disable Hand View Sway",
+            description = "Disables your arm/held item from drifting across the screen when moving your mouse.",
+            category = "Misc", subcategory = "Fixes, QOL, and Tweaks"
+    )
+    public static boolean noHandViewSway = false;
 
     @Switch(
             name = "Old Lunar/CheatBreaker Block-Hit Position",

--- a/src/main/java/org/polyfrost/overflowanimations/mixin/ItemRendererMixin.java
+++ b/src/main/java/org/polyfrost/overflowanimations/mixin/ItemRendererMixin.java
@@ -110,4 +110,9 @@ public abstract class ItemRendererMixin {
         return OldAnimationsSettings.INSTANCE.enabled ? OldAnimationsSettings.INSTANCE.reequipSpeed : original;
     }
 
+    @Inject(method = "rotateWithPlayerRotations", at = @At(value = "HEAD"), cancellable = true)
+    private void removeHandSway(EntityPlayerSP entityplayerspIn, float partialTicks, CallbackInfo ci) {
+        if (OldAnimationsSettings.noHandViewSway) ci.cancel();
+    }
+
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
when moving your mouse your hand sways. option to remove that

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
easier to test with high sense. swing your mouse around and see your arm lag behind your view. turn on this config and see again, it wont move anymore

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
+ Add option to disable hand swaying when moving camera
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->