### PR TITLE
Fixed: Three swing speed parameters not working correctly

### DIFF
--- a/src/main/java/org/polyfrost/overflowanimations/mixin/EntityLivingBaseMixin.java
+++ b/src/main/java/org/polyfrost/overflowanimations/mixin/EntityLivingBaseMixin.java
@@ -52,14 +52,16 @@ public abstract class EntityLivingBaseMixin extends Entity {
     @Inject(method = "getArmSwingAnimationEnd()I", at = @At("HEAD"), cancellable = true)
     public void overflowAnimations$modifySwingSpeed(CallbackInfoReturnable<Integer> cir) {
         OldAnimationsSettings settings = OldAnimationsSettings.INSTANCE;
-        if (OldAnimationsSettings.globalPositions && settings.enabled) {
-            if (isPotionActive(Potion.digSpeed) && !OldAnimationsSettings.ignoreHaste) {
-                cir.setReturnValue((6 - (1 + getActivePotionEffect(Potion.digSpeed).getAmplifier())) * Math.max((int) Math.exp(-settings.itemSwingSpeedHaste), 1));
-            } else if (isPotionActive(Potion.digSlowdown) && !OldAnimationsSettings.ignoreFatigue) {
-                cir.setReturnValue((6 + (1 + getActivePotionEffect(Potion.digSlowdown).getAmplifier())) * 2 * Math.max((int) Math.exp(-settings.itemSwingSpeedFatigue), 1));
-            } else {
-                cir.setReturnValue(6 * Math.max((int) Math.exp(-settings.itemSwingSpeed), 1));
-            }
+        if (!OldAnimationsSettings.globalPositions || !settings.enabled) return;
+        int length = 6;
+        if (isPotionActive(Potion.digSpeed) && !OldAnimationsSettings.ignoreHaste) {
+            length -= (1 + getActivePotionEffect(Potion.digSpeed).getAmplifier());
+            cir.setReturnValue(Math.max((int) (length * Math.exp(-settings.itemSwingSpeedHaste)), 1));
+        } else if (isPotionActive(Potion.digSlowdown) && !OldAnimationsSettings.ignoreFatigue) {
+            length += (1 + getActivePotionEffect(Potion.digSlowdown).getAmplifier()) * 2;
+            cir.setReturnValue(Math.max((int) (length * Math.exp(-settings.itemSwingSpeedFatigue)), 1));
+        } else {
+            cir.setReturnValue(Math.max((int) (length * Math.exp(-settings.itemSwingSpeed)), 1));
         }
     }
 


### PR DESCRIPTION
## Description
- Fixed bug where `itemSwingSpeed`, `itemSwingSpeedHaste`, and `itemSwingSpeedFatigue` didn’t affect swing speed correctly.
  > When swing speed values were set to 0 or below, the swing speed would decrease as expected,
  > but when set between 0 and 1, there was no noticeable change in the swing speed.
